### PR TITLE
Fix builds, given the latest libnds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: devkitARM build
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, dev ]
   pull_request:
     branches: [ main ]
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: devkitARM build
+name: Build
 
 on:
   push:
@@ -7,14 +7,10 @@ on:
     branches: [ main ]
 
 jobs:
-  build-dslibris-nds:
+  Build:
     runs-on: ubuntu-latest
     container: devkitpro/devkitarm
     steps:
     - uses: actions/checkout@v2
     - name: make
       run: make
-    # - name: make check
-    #   run: make check
-    # - name: make distcheck
-    #   run: make distcheck

--- a/include/app.h
+++ b/include/app.h
@@ -85,7 +85,7 @@ https://github.com/rhaleblian/dslibris
 class App {
 	private:
 	void InitScreens();
-	void SetBrightness(int b);
+	void SetBrightness(u8 b);
 	void SetOrientation(bool flip);
 	void WifiInit();
 	bool WifiConnect();

--- a/include/text.h
+++ b/include/text.h
@@ -31,7 +31,7 @@ using namespace std;
 
 class App;
 int asciiart();
-const char* ErrorString(uint);
+const char* ErrorString(u8);
 
 typedef struct TextFaceRec_ {
 	char file_path[128];

--- a/source/app.cpp
+++ b/source/app.cpp
@@ -36,7 +36,6 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 #include "nds/arm9/background.h"
 #include "nds/arm9/input.h"
 
-#include "ndsx_brightness.h"
 #include "types.h"
 #include "main.h"
 #include "parse.h"
@@ -318,16 +317,15 @@ int App::Run(void)
 	exit(0);
 }
 
-void App::SetBrightness(int b)
+void App::SetBrightness(u8 b)
 {
-	if(b<0) brightness = 0;
-	brightness = b%4;
-	fifoSendValue32(BACKLIGHT_FIFO,brightness);
+	brightness = b % 4;
+	setBrightness(3, brightness);
 }
 
 void App::CycleBrightness()
 {
-	++brightness%=4;
+	++brightness %= 4;
 	SetBrightness(brightness);
 }
 

--- a/source/text.cpp
+++ b/source/text.cpp
@@ -888,7 +888,7 @@ int asciiart() {
   return error;
 }
 
-const char* ErrorString(uint c) {
+const char* ErrorString(u8 c) {
 	switch (c) {
 		case 0:
 		return "ok";


### PR DESCRIPTION
This fixes brightness calls.  The build action will succeed again, but video and typesetting may not be working.