### PR TITLE
Fixed a core memory leak involving book pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,13 @@ Once `dkp-pacman` is installed, can get needed packages via
 
     sudo dkp-pacman -S $(cat requirements.txt)
 
+Afterwards we need to install the legacy version of freetype that
+dslibris relies on.
+
+    sudo ./lockfix/setup-noinline
+    ./install-freetype 2.4.8
+    sudo ./lockfix/revert-inline
+
 ## Building
 
 To build the program, assure devkitARM is available to your shell:


### PR DESCRIPTION
Fixed the main problem I had set out to initially fix before I realised there was the issue with rendering glyphs.
If you opened a book and then closed it, it would leak memory and eventually on reopening and closing books enough times the system would crash. Now pages are properly disposed of after a book is closed, eliminating the leak.